### PR TITLE
Update heatmapcode.R

### DIFF
--- a/heatmapcode.R
+++ b/heatmapcode.R
@@ -1,6 +1,6 @@
 HeatmapGenerator <- function() {
   
-  setwd("~/Documents/R_dir")
+  setwd("~/R_dir")
   infile <- "EXAMPLE.txt"
   outfile <- "EXAMPLE_output.tiff"
   genexp <- read.table(infile, header = TRUE, sep="", stringsAsFactors=FALSE)


### PR DESCRIPTION
Shortening the working directory path corrects a "setwd()" error if the Rscript is run in RStudio.

The error message read: Error in setwd("~/Documents/R_dir") : cannot change working directory
